### PR TITLE
ci: :green_heart: fix npm publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,7 +34,7 @@ jobs:
         run: bun run build
 
       - name: Publish to npm
-        run: bunx pnpm publish --provenance --access public
+        run: bunx pnpm publish --provenance --access public --no-git-checks
 
   publish-jsr:
     name: Publish to JSR


### PR DESCRIPTION
## Summary

- リリースタグからワークフローがトリガーされると、Gitがdetached HEAD状態になる
- git checkを外して対応