### PR TITLE
ci: :green_heart: cffnpwr/actions参照のrenovate追従回復とcommitlint追加

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,17 @@
+name: commitlint
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow_ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  commitlint:
+    uses: cffnpwr/actions/.github/workflows/commitlint.yaml@8c50ed3d1d5b4b7a113385add28e75cd229add0d # main
+    permissions:
+      contents: read

--- a/.github/workflows/github-actions-lint.yaml
+++ b/.github/workflows/github-actions-lint.yaml
@@ -17,6 +17,6 @@ permissions: {}
 
 jobs:
   lint:
-    uses: cffnpwr/actions/.github/workflows/github-actions-lint.yaml@827d6803313793c29f98826d5d9c00e92da976cb
+    uses: cffnpwr/actions/.github/workflows/github-actions-lint.yaml@827d6803313793c29f98826d5d9c00e92da976cb # main
     permissions:
       contents: read

--- a/.github/workflows/semantic-pr-title.yaml
+++ b/.github/workflows/semantic-pr-title.yaml
@@ -18,4 +18,4 @@ permissions:
 
 jobs:
   semantic-pr-title:
-    uses: cffnpwr/actions/.github/workflows/semantic-pr-title.yaml@827d6803313793c29f98826d5d9c00e92da976cb
+    uses: cffnpwr/actions/.github/workflows/semantic-pr-title.yaml@827d6803313793c29f98826d5d9c00e92da976cb # main

--- a/.github/workflows/status-check.yaml
+++ b/.github/workflows/status-check.yaml
@@ -17,8 +17,10 @@ permissions: {}
 
 jobs:
   status-check:
-    uses: cffnpwr/actions/.github/workflows/status-check.yaml@827d6803313793c29f98826d5d9c00e92da976cb
+    uses: cffnpwr/actions/.github/workflows/status-check.yaml@827d6803313793c29f98826d5d9c00e92da976cb # main
     permissions:
+      contents: read
+      actions: read
       pull-requests: read
       checks: read
       statuses: read


### PR DESCRIPTION
## What

- `github-actions-lint.yaml` / `semantic-pr-title.yaml` / `status-check.yaml` の `cffnpwr/actions/...@<sha>` 参照に `# main` アンカーコメントを付与
- `status-check.yaml` の呼び出し permissions に `contents: read` と `actions: read` を追加
- `commitlint.yaml` を新規追加（`cffnpwr/actions/.github/workflows/commitlint.yaml@<sha>` を `pull_request` で呼び出し。設定は shared `@cffnpwr/commitlint-config` を使用）

## Why

- コメント無しの生SHA pinはrenovateに追跡されず、cffnpwr/actionsのmain更新にdigest更新PRで追従できていなかった（Closes #163）。`# main` アンカーで追跡対象に戻す
- Issueの受け入れ基準に沿い、status-check呼び出しへ `contents: read` / `actions: read` を追加
- commitlintをCIに追加し、PRのコミットメッセージ規約を機械的に検証する

## Impact

- renovateがDependency Dashboard再スキャン後に当該参照を追跡し、main HEADへのdigest更新PRを生成する
- 破壊的変更なし。既存3ファイルのSHAは据え置き（`# main`付与のみ）で、更新はrenovateに委譲
- commitlintはstatus-checkの集約対象に含まれる。cffnpwr/actionsのstatus-checkは `gh pr checks` で自身（"Status check"）を除く全チェックを監視する実装のため、commitlint workflowの追加だけで自動的に対象となる（status-check側の変更は不要）
- commitlintはマージコミット等（`^Merge` 等）をcommitlintのdefaultIgnoresにより無視する。これはcommitlintの標準挙動
- Issue記載の `flake-check.yaml` は #164 で削除済みのため対象外
