### PR TITLE
chore: :wrench: tsconfig を @cffnpwr/tsconfig/bun に移行し import を .ts に変更

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "typescript-eslint": "8.63.0",
       },
       "devDependencies": {
+        "@cffnpwr/tsconfig": "1.0.0",
         "@types/bun": "1.3.14",
         "@types/eslint-plugin-jsx-a11y": "6.10.1",
         "eslint": "10.7.0",
@@ -69,6 +70,8 @@
     "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@cffnpwr/tsconfig": ["@cffnpwr/tsconfig@1.0.0", "", {}, "sha512-tZMQ89j0F8YqG97h0XwPcdZyOe8ipO6VfnrUIkwp7PYaNJ7xnu9wgSUr4qYbCbxWjNDJx2wpymh0vjaeYiCCKA=="],
 
     "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "typescript-eslint": "8.63.0"
   },
   "devDependencies": {
+    "@cffnpwr/tsconfig": "1.0.0",
     "@types/bun": "1.3.14",
     "@types/eslint-plugin-jsx-a11y": "6.10.1",
     "eslint": "10.7.0",

--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -4,8 +4,8 @@ import eslintReact from "@eslint-react/eslint-plugin";
 import jsxA11yPlugin from "eslint-plugin-jsx-a11y";
 import reactHooksPlugin from "eslint-plugin-react-hooks";
 
-import { defineConfig } from "../utils/define-config.js";
-import { excludeLegacyRules } from "../utils/exclude-legacy-rules.js";
+import { defineConfig } from "../utils/define-config.ts";
+import { excludeLegacyRules } from "../utils/exclude-legacy-rules.ts";
 
 const eslintReactRecommended = eslintReact.configs["recommended-typescript"];
 

--- a/src/configs/stylistic.ts
+++ b/src/configs/stylistic.ts
@@ -2,7 +2,7 @@ import type { Linter } from "eslint";
 
 import stylisticPlugin from "@stylistic/eslint-plugin";
 
-import { defineConfig } from "../utils/define-config.js";
+import { defineConfig } from "../utils/define-config.ts";
 
 export const stylistic = (): Linter.Config[] => {
   return defineConfig([

--- a/src/configs/tailwind.ts
+++ b/src/configs/tailwind.ts
@@ -3,7 +3,7 @@ import type { Linter } from "eslint";
 import betterTailwindPlugin from "eslint-plugin-better-tailwindcss";
 import tailwindPlugin from "eslint-plugin-tailwindcss";
 
-import { defineConfig } from "../utils/define-config.js";
+import { defineConfig } from "../utils/define-config.ts";
 
 export const tailwind = (): Linter.Config[] => {
   return defineConfig([

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -6,8 +6,8 @@ import perfectionistPlugin from "eslint-plugin-perfectionist";
 import unusedImportsPlugin from "eslint-plugin-unused-imports";
 import tsEslint from "typescript-eslint";
 
-import { defineConfig } from "../utils/define-config.js";
-import { excludeLegacyRules } from "../utils/exclude-legacy-rules.js";
+import { defineConfig } from "../utils/define-config.ts";
+import { excludeLegacyRules } from "../utils/exclude-legacy-rules.ts";
 
 export const typescript = (): Linter.Config[] => {
   return defineConfig([

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import type { Linter } from "eslint";
 
-import { react } from "./configs/react.js";
-import { stylistic } from "./configs/stylistic.js";
-import { tailwind } from "./configs/tailwind.js";
-import { typescript } from "./configs/typescript.js";
+import { react } from "./configs/react.ts";
+import { stylistic } from "./configs/stylistic.ts";
+import { tailwind } from "./configs/tailwind.ts";
+import { typescript } from "./configs/typescript.ts";
 
 export type CffnpwrConfigOptions = {
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,26 +1,4 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ESNext"],
-    "types": ["node"],
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "isolatedModules": true,
-    "verbatimModuleSyntax": true,
-    "resolveJsonModule": true,
-    "declaration": true,
-    "declarationMap": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noUncheckedIndexedAccess": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
-  },
+  "extends": "@cffnpwr/tsconfig/bun",
   "include": ["src/**/*", "*.config.ts"]
 }


### PR DESCRIPTION
## 概要

TypeScript設定を共有パッケージ `@cffnpwr/tsconfig/bun` に移行する。

- `tsconfig.json` の `compilerOptions` を共有 base 設定に委譲し、`extends` と `include` のみに削減。未使用だった `paths`（`@/*`）も削除。
- `src/` 配下の相対importの拡張子を `.js` → `.ts` に変更（共有 base 設定の `allowImportingTsExtensions` により成立）。
- `@cffnpwr/tsconfig@1.0.0` を devDependencies に追加。

## 背景・理由

自プロジェクト共通のTypeScript設定を `@cffnpwr/tsconfig` に集約し、各リポジトリでの `compilerOptions` 重複を解消するため。

## 影響

破壊的変更なし（ライブラリの公開API・ビルド成果物に変化なし）。共有 base 設定の採用により以下の設定が変化する。

- `module`: `ESNext` → `Preserve`
- `types`: `["node"]` → `["bun"]`（`@types/bun` と整合）
- `moduleDetection: force` を新規有効化

検証: `tsc --noEmit` / `bun run build`（tsdown）/ `bun run lint` / `jsr publish --dry-run` すべて通過。
