### PR TITLE
ci: :wrench: migrate create-github-app-token to client-id

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-metadata: read
           permission-contents: write


### PR DESCRIPTION
## What
`.github/workflows/release-please.yaml` の `actions/create-github-app-token` で、`app-id: ${{ secrets.RELEASE_APP_ID }}` を `client-id: ${{ vars.RELEASE_CLIENT_ID }}` に置き換えた（1箇所）。

## Why
`app-id` は非推奨で、`action.yml` に `deprecationMessage: "Use 'client-id' instead."` が付いている。非推奨入力が削除された時点でリリースパイプラインが止まる。

## Impact
- リポジトリ変数 `RELEASE_CLIENT_ID` を参照する。値は GitHub App `cffnpwr-release-bot` の Client ID で、設定済み。App ID とは別の識別子
- シークレット `RELEASE_APP_ID` はこのPRのマージと動作確認の後に削除する
- `private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}` は変更していない

Closes #228
